### PR TITLE
Remove `defaultProps` usage

### DIFF
--- a/part-1/components/button.jsx
+++ b/part-1/components/button.jsx
@@ -14,11 +14,6 @@ const sizesLookup = {
 }
 
 export const Button = (props) => {
-  const { variant, size, ...rest } = props
+  const { variant = 'primary', size = 'medium', ...rest } = props
   return <button {...rest} className={`${baseClasses} ${variantsLookup[variant]} ${sizesLookup[size]}`} />
-}
-
-Button.defaultProps = {
-  variant: 'primary',
-  size: 'medium',
 }

--- a/part-2/components/button.tsx
+++ b/part-2/components/button.tsx
@@ -19,17 +19,12 @@ type ButtonVariant = keyof typeof variantsLookup
 type ButtonSize = keyof typeof sizesLookup
 
 interface ButtonProps extends Omit<ComponentProps<'button'>, 'className'> {
-  variant: ButtonVariant
-  size: ButtonSize
+  variant?: ButtonVariant
+  size?: ButtonSize
   className?: "The className attribute is not allowed (and won't do anything)"
 }
 
 export const Button = (props: ButtonProps) => {
-  const { variant, size, ...rest } = props
+  const { variant = 'primary', size = 'medium', ...rest } = props
   return <button {...rest} className={`${baseClasses} ${variantsLookup[variant]} ${sizesLookup[size]}`} />
-}
-
-Button.defaultProps = {
-  variant: 'primary',
-  size: 'medium',
 }


### PR DESCRIPTION
Not sure if PR's are welcomed but basically I just wanted to bring your attention to the usage of `defaultProps`, it looks like it will eventually get deprecated[^deprecated-defaultprops]. The fix is simple by using default values when destructuring the props.

If this change is accepted then the article content would also need updated (but I am sure you know that).


Feel free to close this if it doesn't suit. 


BTW, the articles are great and I am looking forward to more!

[^deprecated-defaultprops]: https://react-typescript-cheatsheet.netlify.app/docs/basic/getting-started/default_props/#you-may-not-need-defaultprops


